### PR TITLE
Some improvements for chaincode languages and metrics

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -53,3 +53,9 @@ For storing backup contents, using an Argo flow seemed more convenient. Volume s
 Similar to above, cloud native disk snaphots do not provide any consistency guarantees.
 
 Also, taking snapshot and restoring from it requires lots of cloud specific scripting. Our flow feels much more convenient as it will work on any cloud provider or even locally.
+
+### Why are node chaincode deployments failing with a weird DNS error?
+
+If you're seeing an error like the one below on AWS EKS, it's because docker in docker is not allowed to access the host network by default. If you are deploying your worker nodes via the AWS Console, you can set `--enable-docker-bridge true` in the `BootstrapArugments` parameters when deploying your stack. If deploying using eksctl, take a look at this [issue](https://github.com/weaveworks/eksctl/issues/942).
+
+    npm ERR! request to https://registry.npmjs.org/fabric-shim failed, reason: getaddrinfo EAI_AGAIN registry.npmjs.org:443

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ network:
   # defines which chaincodes will be installed to which organizations
   chaincodes:
     - name: very-simple
+      language: node
+      version: "1.0"
       # chaincode will be installed to all peers in these organizations
       orgs: [Karga, Nevergreen, Atlantis]
       # at which channels are we instantiating/upgrading chaincode?
@@ -347,13 +349,19 @@ network:
         # chaincode will be invoked on all peers in these organizations
         orgs: [Karga, Nevergreen, Atlantis]
         policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: '{"function":"ping","Args":[""]}'
         
     - name: even-simpler
+      language: node
+      version: "1.0"
       orgs: [Karga, Atlantis]
       channels:
       - name: private-karga-atlantis
         orgs: [Karga, Atlantis]
         policy: OR('KargaMSP.member','AtlantisMSP.member')
+      invoke:
+        function: '{"function":"ping","Args":[""]}'
 ```
 
 For chart specific configuration, please refer to the comments in the relevant [values.yaml](fabric-kube/hlf-kube/values.yaml) files.

--- a/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
+++ b/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
@@ -81,19 +81,20 @@ spec:
 # second level: chaincode templates
 {{- range $i, $chaincode := .Values.network.chaincodes }}
 {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
+{{- $version := $chaincode.version | default $.Values.chaincode.version }}
   - name: chaincode--{{ $chaincode.name }}
     steps:
     {{- if $.Values.flow.install.enabled }}
-    - - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
-        template: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+    - - name: install-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}
+        template: install-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}
     {{- end }}
     {{- if $.Values.flow.instantiate.enabled }}
-    - - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
-        template: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+    - - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}
+        template: instantiate-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}
     {{- end }}
     {{- if $.Values.flow.upgrade.enabled }}
-    - - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
-        template: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+    - - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}
+        template: upgrade-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}
     {{- end }}
     {{- if $.Values.flow.invoke.enabled }}
     - - name: invoke-chaincode--{{ $chaincode.name }}
@@ -107,7 +108,7 @@ spec:
 {{- range $i, $chaincode := .Values.network.chaincodes }}
 {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
 {{- $_ := set $vars "firstStep" true }}
-  - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+  - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}
     steps:
      
 {{- range $orgName := $chaincode.orgs }}
@@ -121,8 +122,8 @@ spec:
 {{- if or $vars.firstStep (not $.Values.flow.install.parallel) }}
     - 
 {{- end }}
-      - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
-        template: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
+      - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
+        template: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
 {{- $_ := set $vars "firstStep" false }}
 {{- end }} {{- /* peerIndex */ -}} 
 {{- end }} {{- /* if org */ -}} 
@@ -138,7 +139,7 @@ spec:
 {{- range $i, $chaincode := .Values.network.chaincodes }}
 {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
 {{- $_ := set $vars "firstStep" true }}
-  - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+  - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}
     steps:
 {{- range $channel := $chaincode.channels }}
 {{- $orgName := index $channel.orgs 0 }}
@@ -152,8 +153,8 @@ spec:
 {{- if or $vars.firstStep (not $.Values.flow.instantiate.parallel) }}
     - 
 {{- end }}
-      - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
-        template: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
+      - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
+        template: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
 
 {{- $_ := set $vars "firstStep" false }}
 {{- end }} {{- /* if org */ -}} 
@@ -169,7 +170,7 @@ spec:
 {{- range $i, $chaincode := .Values.network.chaincodes }}
 {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
 {{- $_ := set $vars "firstStep" true }}
-  - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+  - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}
     steps:
 {{- range $channel := $chaincode.channels }}
 {{- $orgName := index $channel.orgs 0 }}
@@ -183,8 +184,8 @@ spec:
 {{- if or $vars.firstStep (not $.Values.flow.instantiate.parallel) }}
     - 
 {{- end }}
-      - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
-        template: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
+      - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
+        template: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | default $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
 
 {{- $_ := set $vars "firstStep" false }}
 {{- end }} {{- /* if org */ -}} 
@@ -240,8 +241,10 @@ spec:
 {{- $peerStartIndex := (not $org.Template.Start) | ternary 0 $org.Template.Start | int }}
 {{- range $peerIndex := untilStep $peerStartIndex (add $peerStartIndex $org.Template.Count | int) 1 }}
 {{- $peer := (printf "peer%s" ($peerIndex | toString)) }}
+{{- $language := $chaincode.language | default $.Values.chaincode.language }}
+{{- $version := $chaincode.version | default $.Values.chaincode.version }}
 
-  - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
+  - name: install-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
     # chaincode: {{ $chaincode.name }}
     # org: {{ $org.Name }}
     # peer: {{ $peer }}
@@ -250,18 +253,18 @@ spec:
       limit: {{ $.Values.retryCount }}
     container:
       # chaincode is packed with tar, first extract it
-      {{- if eq $chaincode.language "golang" }}
+      {{- if eq $language "golang" }}
       image: hyperledger/fabric-tools:{{ $.Values.hyperledgerVersion }}
       command: ["sh", "-c", "mkdir -p $GOPATH/src/chaincode && \
                              tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C $GOPATH/src/chaincode && \ 
                              peer chaincode install -p chaincode/{{ $chaincode.name }} -n {{ $chaincode.name }} \
-                                  -v {{ $chaincode.version }} -l {{ $chaincode.language }}"]
+                                  -v {{ $version }} -l {{ $language }}"]
       {{- else }}
       image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
       command: ["sh", "-c", "mkdir -p /chaincode && \
                              tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C /chaincode && \ 
                              peer chaincode install -p /chaincode/{{ $chaincode.name }} -n {{ $chaincode.name }} \
-                                  -v {{ $chaincode.version }} -l {{ $chaincode.language }}"]
+                                  -v {{ $version }} -l {{ $language }}"]
       {{- end }}
 
       volumeMounts:
@@ -313,8 +316,10 @@ spec:
 
 {{- $peerStartIndex := (not $org.Template.Start) | ternary 0 $org.Template.Start | int }}
 {{- $peer := (printf "peer%s" ($peerStartIndex | toString)) }}
+{{- $language := $chaincode.language | default $.Values.chaincode.language }}
+{{- $version := $chaincode.version | default $.Values.chaincode.version }}
 
-  - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
+  - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
     # chaincode: {{ $chaincode.name }}
     # channel: {{ $channel.name }}
     # org: {{ $org.Name }}
@@ -324,7 +329,7 @@ spec:
       limit: {{ $.Values.retryCount }}
     container:
       image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
-      command: ["sh", "-c", "peer chaincode instantiate -C {{ $channel.name }} -n {{ $chaincode.name }} -v {{ $chaincode.version }} -l {{ $chaincode.language }} -P \"{{ $channel.policy }}\" -o {{ $ordererAddress }}:7050 -c '{\"Args\":[\"\"]}' \
+      command: ["sh", "-c", "peer chaincode instantiate -C {{ $channel.name }} -n {{ $chaincode.name }} -v {{ $version }} -l {{ $language }} -P \"{{ $channel.policy }}\" -o {{ $ordererAddress }}:7050 -c '{\"Args\":[\"\"]}' \
                                 {{- if $.Values.tlsEnabled }}
                                     --tls --cafile /hlf_config/orderer-tlsca/tlscacert.pem \
                                 {{- end }}
@@ -378,8 +383,10 @@ spec:
 
 {{- $peerStartIndex := (not $org.Template.Start) | ternary 0 $org.Template.Start | int }}
 {{- $peer := (printf "peer%s" ($peerStartIndex | toString)) }}
+{{- $language := $chaincode.language | default $.Values.chaincode.language }}
+{{- $version := $chaincode.version | default $.Values.chaincode.version }}
 
-  - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
+  - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
     # chaincode: {{ $chaincode.name }}
     # channel: {{ $channel.name }}
     # org: {{ $org.Name }}
@@ -389,7 +396,7 @@ spec:
       limit: {{ $.Values.retryCount }}
     container:
       image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
-      command: ["sh", "-c", "peer chaincode upgrade -C {{ $channel.name }} -n {{ $chaincode.name }} -v {{ $chaincode.version }} -l {{ $chaincode.language }} -P \"{{ $channel.policy }}\" -o {{ $ordererAddress }}:7050 -c '{\"Args\":[\"\"]}' \
+      command: ["sh", "-c", "peer chaincode upgrade -C {{ $channel.name }} -n {{ $chaincode.name }} -v {{ $version }} -l {{ $language }} -P \"{{ $channel.policy }}\" -o {{ $ordererAddress }}:7050 -c '{\"Args\":[\"\"]}' \
                                 {{- if $.Values.tlsEnabled }}
                                     --tls --cafile /hlf_config/orderer-tlsca/tlscacert.pem \
                                 {{- end }}

--- a/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
+++ b/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
@@ -84,16 +84,16 @@ spec:
   - name: chaincode--{{ $chaincode.name }}
     steps:
     {{- if $.Values.flow.install.enabled }}
-    - - name: install-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
-        template: install-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
+    - - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+        template: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
     {{- end }}
     {{- if $.Values.flow.instantiate.enabled }}
-    - - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
-        template: instantiate-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
+    - - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+        template: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
     {{- end }}
     {{- if $.Values.flow.upgrade.enabled }}
-    - - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
-        template: upgrade-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
+    - - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
+        template: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
     {{- end }}
     {{- if $.Values.flow.invoke.enabled }}
     - - name: invoke-chaincode--{{ $chaincode.name }}
@@ -107,7 +107,7 @@ spec:
 {{- range $i, $chaincode := .Values.network.chaincodes }}
 {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
 {{- $_ := set $vars "firstStep" true }}
-  - name: install-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
+  - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
     steps:
      
 {{- range $orgName := $chaincode.orgs }}
@@ -121,8 +121,8 @@ spec:
 {{- if or $vars.firstStep (not $.Values.flow.install.parallel) }}
     - 
 {{- end }}
-      - name: install-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
-        template: install-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
+      - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
+        template: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
 {{- $_ := set $vars "firstStep" false }}
 {{- end }} {{- /* peerIndex */ -}} 
 {{- end }} {{- /* if org */ -}} 
@@ -138,7 +138,7 @@ spec:
 {{- range $i, $chaincode := .Values.network.chaincodes }}
 {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
 {{- $_ := set $vars "firstStep" true }}
-  - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
+  - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
     steps:
 {{- range $channel := $chaincode.channels }}
 {{- $orgName := index $channel.orgs 0 }}
@@ -152,8 +152,8 @@ spec:
 {{- if or $vars.firstStep (not $.Values.flow.instantiate.parallel) }}
     - 
 {{- end }}
-      - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
-        template: instantiate-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
+      - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
+        template: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
 
 {{- $_ := set $vars "firstStep" false }}
 {{- end }} {{- /* if org */ -}} 
@@ -169,7 +169,7 @@ spec:
 {{- range $i, $chaincode := .Values.network.chaincodes }}
 {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
 {{- $_ := set $vars "firstStep" true }}
-  - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}
+  - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}
     steps:
 {{- range $channel := $chaincode.channels }}
 {{- $orgName := index $channel.orgs 0 }}
@@ -183,8 +183,8 @@ spec:
 {{- if or $vars.firstStep (not $.Values.flow.instantiate.parallel) }}
     - 
 {{- end }}
-      - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
-        template: upgrade-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
+      - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
+        template: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
 
 {{- $_ := set $vars "firstStep" false }}
 {{- end }} {{- /* if org */ -}} 
@@ -241,7 +241,7 @@ spec:
 {{- range $peerIndex := untilStep $peerStartIndex (add $peerStartIndex $org.Template.Count | int) 1 }}
 {{- $peer := (printf "peer%s" ($peerIndex | toString)) }}
 
-  - name: install-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
+  - name: install-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
     # chaincode: {{ $chaincode.name }}
     # org: {{ $org.Name }}
     # peer: {{ $peer }}
@@ -250,18 +250,18 @@ spec:
       limit: {{ $.Values.retryCount }}
     container:
       # chaincode is packed with tar, first extract it
-      {{- if eq $.Values.chaincode.language "golang" }}
+      {{- if eq $chaincode.language "golang" }}
       image: hyperledger/fabric-tools:{{ $.Values.hyperledgerVersion }}
       command: ["sh", "-c", "mkdir -p $GOPATH/src/chaincode && \
                              tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C $GOPATH/src/chaincode && \ 
                              peer chaincode install -p chaincode/{{ $chaincode.name }} -n {{ $chaincode.name }} \
-                                  -v {{ $.Values.chaincode.version }} -l {{ $.Values.chaincode.language }}"]
+                                  -v {{ $chaincode.version }} -l {{ $chaincode.language }}"]
       {{- else }}
       image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
       command: ["sh", "-c", "mkdir -p /chaincode && \
                              tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C /chaincode && \ 
                              peer chaincode install -p /chaincode/{{ $chaincode.name }} -n {{ $chaincode.name }} \
-                                  -v {{ $.Values.chaincode.version }} -l {{ $.Values.chaincode.language }}"]
+                                  -v {{ $chaincode.version }} -l {{ $chaincode.language }}"]
       {{- end }}
 
       volumeMounts:
@@ -314,7 +314,7 @@ spec:
 {{- $peerStartIndex := (not $org.Template.Start) | ternary 0 $org.Template.Start | int }}
 {{- $peer := (printf "peer%s" ($peerStartIndex | toString)) }}
 
-  - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
+  - name: instantiate-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
     # chaincode: {{ $chaincode.name }}
     # channel: {{ $channel.name }}
     # org: {{ $org.Name }}
@@ -324,7 +324,7 @@ spec:
       limit: {{ $.Values.retryCount }}
     container:
       image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
-      command: ["sh", "-c", "peer chaincode instantiate -C {{ $channel.name }} -n {{ $chaincode.name }} -v {{ $.Values.chaincode.version }} -l {{ $.Values.chaincode.language }} -P \"{{ $channel.policy }}\" -o {{ $ordererAddress }}:7050 -c '{\"Args\":[\"\"]}' \
+      command: ["sh", "-c", "peer chaincode instantiate -C {{ $channel.name }} -n {{ $chaincode.name }} -v {{ $chaincode.version }} -l {{ $chaincode.language }} -P \"{{ $channel.policy }}\" -o {{ $ordererAddress }}:7050 -c '{\"Args\":[\"\"]}' \
                                 {{- if $.Values.tlsEnabled }}
                                     --tls --cafile /hlf_config/orderer-tlsca/tlscacert.pem \
                                 {{- end }}
@@ -379,7 +379,7 @@ spec:
 {{- $peerStartIndex := (not $org.Template.Start) | ternary 0 $org.Template.Start | int }}
 {{- $peer := (printf "peer%s" ($peerStartIndex | toString)) }}
 
-  - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $.Values.chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
+  - name: upgrade-chaincode--{{ $chaincode.name }}-{{ $chaincode.version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
     # chaincode: {{ $chaincode.name }}
     # channel: {{ $channel.name }}
     # org: {{ $org.Name }}
@@ -389,7 +389,7 @@ spec:
       limit: {{ $.Values.retryCount }}
     container:
       image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
-      command: ["sh", "-c", "peer chaincode upgrade -C {{ $channel.name }} -n {{ $chaincode.name }} -v {{ $.Values.chaincode.version }} -l {{ $.Values.chaincode.language }} -P \"{{ $channel.policy }}\" -o {{ $ordererAddress }}:7050 -c '{\"Args\":[\"\"]}' \
+      command: ["sh", "-c", "peer chaincode upgrade -C {{ $channel.name }} -n {{ $chaincode.name }} -v {{ $chaincode.version }} -l {{ $chaincode.language }} -P \"{{ $channel.policy }}\" -o {{ $ordererAddress }}:7050 -c '{\"Args\":[\"\"]}' \
                                 {{- if $.Values.tlsEnabled }}
                                     --tls --cafile /hlf_config/orderer-tlsca/tlscacert.pem \
                                 {{- end }}
@@ -456,7 +456,7 @@ spec:
     container:
       image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
       # chaincode is packed with tar, first extract it
-      command: ["sh", "-c", "peer chaincode invoke -C {{ $channel.name }} -n {{ $chaincode.name }} -o {{ $ordererAddress }}:7050 -c {{ $.Values.flow.invoke.function | replace "\"" "\\\"" | squote }} \
+      command: ["sh", "-c", "peer chaincode invoke -C {{ $channel.name }} -n {{ $chaincode.name }} -o {{ $ordererAddress }}:7050 -c {{ $chaincode.invoke.function | replace "\"" "\\\"" | squote }} \
                                 {{- if $.Values.tlsEnabled }}
                                     --tls --cafile /hlf_config/orderer-tlsca/tlscacert.pem \
                                 {{- end }}

--- a/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
+++ b/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
@@ -249,12 +249,20 @@ spec:
     retryStrategy:
       limit: {{ $.Values.retryCount }}
     container:
-      image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
       # chaincode is packed with tar, first extract it
+      {{- if eq $.Values.chaincode.language "golang" }}
+      image: hyperledger/fabric-tools:{{ $.Values.hyperledgerVersion }}
+      command: ["sh", "-c", "mkdir -p $GOPATH/src/chaincode && \
+                             tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C $GOPATH/src/chaincode && \ 
+                             peer chaincode install -p chaincode/{{ $chaincode.name }} -n {{ $chaincode.name }} \
+                                  -v {{ $.Values.chaincode.version }} -l {{ $.Values.chaincode.language }}"]
+      {{- else }}
+      image: hyperledger/fabric-peer:{{ $.Values.hyperledgerVersion }}
       command: ["sh", "-c", "mkdir -p /chaincode && \
                              tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C /chaincode && \ 
                              peer chaincode install -p /chaincode/{{ $chaincode.name }} -n {{ $chaincode.name }} \
                                   -v {{ $.Values.chaincode.version }} -l {{ $.Values.chaincode.language }}"]
+      {{- end }}
 
       volumeMounts:
         - mountPath: /etc/hyperledger/fabric/tls/

--- a/fabric-kube/chaincode-flow/values.yaml
+++ b/fabric-kube/chaincode-flow/values.yaml
@@ -44,8 +44,3 @@ flow:
     # we invoke chaincode after instantiate/upgrade to force the peers to actually create the chaincode containers
     enabled: true 
     parallel: true
-    function: '{"function":"ping","Args":[""]}'
-
-chaincode:
-  version: "1.0"
-  language: node

--- a/fabric-kube/hlf-kube/templates/orderer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/orderer-statefulset.yaml
@@ -177,6 +177,20 @@ spec:
         #   value: "7059"
         # - name: ORDERER_GENERAL_CLUSTER_LISTENADDRESS
         #   value: 0.0.0.0
+        {{- if $.Values.metrics.orderer.enabled }}
+        - name: ORDERER_METRICS_PROVIDER
+          value: {{ $.Values.metrics.orderer.provider }}
+        {{- if eq $.Value.metrics.orderer.provider "statsd" }}
+        - name: ORDERER_METRICS_STATSD_NETWORK
+          value: {{ $.Values.metrics.orderer.statsd.network }}
+        - name: ORDERER_METRICS_STATSD_ADDRESS
+          value: {{ $.Values.metrics.orderer.statsd.address }}
+        - name: ORDERER_METRICS_STATSD_PREFIX
+          value: {{ $org.Name | lower }}--{{ $host.Hostname | lower }}
+        - name: ORDERER_METRICS_STATSD_WRITE_INTERVAL
+          value: {{ $.Values.metrics.orderer.statsd.writeInterval | default 10s }}
+        {{- end }}
+        {{- end }}
 
         - name: HFC_LOGGING
           value: '{"info":"console"}'

--- a/fabric-kube/hlf-kube/templates/orderer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/orderer-statefulset.yaml
@@ -189,7 +189,7 @@ spec:
           value: {{ $org.Name | lower }}--{{ $host.Hostname | lower }}
         - name: ORDERER_METRICS_STATSD_WRITE_INTERVAL
           value: {{ $.Values.metrics.orderer.statsd.writeInterval }}
-        {{- end }}
+        {{- end }} # End statsD section
         {{- end }}
 
         - name: HFC_LOGGING

--- a/fabric-kube/hlf-kube/templates/orderer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/orderer-statefulset.yaml
@@ -180,7 +180,7 @@ spec:
         {{- if $.Values.metrics.orderer.enabled }}
         - name: ORDERER_METRICS_PROVIDER
           value: {{ $.Values.metrics.orderer.provider }}
-        {{- if eq $.Value.metrics.orderer.provider "statsd" }}
+        {{- if eq $.Values.metrics.orderer.provider "statsd" }}
         - name: ORDERER_METRICS_STATSD_NETWORK
           value: {{ $.Values.metrics.orderer.statsd.network }}
         - name: ORDERER_METRICS_STATSD_ADDRESS
@@ -188,7 +188,7 @@ spec:
         - name: ORDERER_METRICS_STATSD_PREFIX
           value: {{ $org.Name | lower }}--{{ $host.Hostname | lower }}
         - name: ORDERER_METRICS_STATSD_WRITE_INTERVAL
-          value: {{ $.Values.metrics.orderer.statsd.writeInterval | default 10s }}
+          value: {{ $.Values.metrics.orderer.statsd.writeInterval }}
         {{- end }}
         {{- end }}
 

--- a/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
@@ -275,7 +275,7 @@ spec:
         {{- if $.Values.metrics.core.enabled }}
         - name: CORE_METRICS_PROVIDER
           value: {{ $.Values.metrics.core.provider }}
-        {{- if eq $.Value.metrics.core.provider "statsd" }}
+        {{- if eq $.Values.metrics.core.provider "statsd" }}
         - name: CORE_METRICS_STATSD_NETWORK
           value: {{ $.Values.metrics.core.statsd.network }}
         - name: CORE_METRICS_STATSD_ADDRESS

--- a/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
@@ -272,7 +272,21 @@ spec:
           value: DEBUG
         - name: GRPC_TRACE
           value:  all
-        
+        {{- if $.Values.metrics.core.enabled }}
+        - name: CORE_METRICS_PROVIDER
+          value: {{ $.Values.metrics.core.provider }}
+        {{- if eq $.Value.metrics.core.provider "statsd" }}
+        - name: CORE_METRICS_STATSD_NETWORK
+          value: {{ $.Values.metrics.core.statsd.network }}
+        - name: CORE_METRICS_STATSD_ADDRESS
+          value: {{ $.Values.metrics.core.statsd.address }}
+        - name: CORE_METRICS_STATSD_PREFIX
+          value: {{ $org.Name | lower }}--{{ $peer | lower }}
+        - name: CORE_METRICS_STATSD_WRITE_INTERVAL
+          value: {{ $.Values.metrics.core.statsd.writeInterval }}
+        {{- end }}
+        {{- end }}
+ 
       # CouchDB container
       - name: couchdb
         image: hyperledger/fabric-couchdb:{{ $.Values.couchdb.version }}

--- a/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
@@ -284,7 +284,7 @@ spec:
           value: {{ $org.Name | lower }}--{{ $peer | lower }}
         - name: CORE_METRICS_STATSD_WRITE_INTERVAL
           value: {{ $.Values.metrics.core.statsd.writeInterval }}
-        {{- end }}
+        {{- end }} # End statsD section
         {{- end }}
  
       # CouchDB container

--- a/fabric-kube/hlf-kube/values.yaml
+++ b/fabric-kube/hlf-kube/values.yaml
@@ -137,7 +137,7 @@ metrics:
     # provider can also be set to prometheus
     provider: statsd
     statsd:
-      network: tcp
+      network: tcp  # tcp or udp
       address: statsd-host:8125
       writeInterval: 10s
 
@@ -147,6 +147,6 @@ metrics:
     # provider can also be set to prometheus
     provider: statsd
     statsd:
-      network: tcp # tcp or udp
+      network: tcp  # tcp or udp
       address: statsd-host:8125
       writeInterval: 10s

--- a/fabric-kube/hlf-kube/values.yaml
+++ b/fabric-kube/hlf-kube/values.yaml
@@ -128,7 +128,25 @@ hlf-kafka:
       enabled: false
       storageClass: default
       size: 16Gi
-    
-    
-      
 
+# metrics settings
+metrics:
+  core:
+    # enable core metrics (peer)
+    enabled: false
+    # provider can also be set to prometheus
+    provider: statsd
+    statsd:
+      network: tcp
+      address: statsd-host:8125
+      writeInterval: 10s
+
+  orderer:
+    # enable orderer metrics
+    enabled: false
+    # provider can also be set to prometheus
+    provider: statsd
+    statsd:
+      network: tcp # tcp or udp
+      address: statsd-host:8125
+      writeInterval: 10s

--- a/fabric-kube/samples/chaincode/high-throughput/high-throughput.go
+++ b/fabric-kube/samples/chaincode/high-throughput/high-throughput.go
@@ -1,0 +1,463 @@
+/*
+ * Copyright IBM Corp All Rights Reserved
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Demonstrates how to handle data in an application with a high transaction volume where the transactions
+ * all attempt to change the same key-value pair in the ledger. Such an application will have trouble
+ * as multiple transactions may read a value at a certain version, which will then be invalid when the first
+ * transaction updates the value to a new version, thus rejecting all other transactions until they're
+ * re-executed.
+ * Rather than relying on serialization of the transactions, which is slow, this application initializes
+ * a value and then accepts deltas of that value which are added as rows to the ledger. The actual value
+ * is then an aggregate of the initial value combined with all of the deltas. Additionally, a pruning
+ * function is provided which aggregates and deletes the deltas to update the initial value. This should
+ * be done during a maintenance window or when there is a lowered transaction volume, to avoid the proliferation
+ * of millions of rows of data.
+ *
+ * @author	Alexandre Pauwels for IBM
+ * @created	17 Aug 2017
+ */
+
+package main
+
+/* Imports
+ * 4 utility libraries for formatting, handling bytes, reading and writing JSON, and string manipulation
+ * 2 specific Hyperledger Fabric specific libraries for Smart Contracts
+ */
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	sc "github.com/hyperledger/fabric/protos/peer"
+)
+
+//SmartContract is the data structure which represents this contract and on which  various contract lifecycle functions are attached
+type SmartContract struct {
+}
+
+// Define Status codes for the response
+const (
+	OK    = 200
+	ERROR = 500
+)
+
+// Init is called when the smart contract is instantiated
+func (s *SmartContract) Init(APIstub shim.ChaincodeStubInterface) sc.Response {
+	return shim.Success(nil)
+}
+
+// Invoke routes invocations to the appropriate function in chaincode
+// Current supported invocations are:
+//	- update, adds a delta to an aggregate variable in the ledger, all variables are assumed to start at 0
+//	- get, retrieves the aggregate value of a variable in the ledger
+//	- pruneFast, deletes all rows associated with the variable and replaces them with a single row containing the aggregate value
+//	- pruneSafe, same as pruneFast except it pre-computed the value and backs it up before performing any destructive operations
+//	- delete, removes all rows associated with the variable
+func (s *SmartContract) Invoke(APIstub shim.ChaincodeStubInterface) sc.Response {
+	// Retrieve the requested Smart Contract function and arguments
+	function, args := APIstub.GetFunctionAndParameters()
+
+	// Route to the appropriate handler function to interact with the ledger appropriately
+	if function == "update" {
+		return s.update(APIstub, args)
+	} else if function == "get" {
+		return s.get(APIstub, args)
+	} else if function == "prunefast" {
+		return s.pruneFast(APIstub, args)
+	} else if function == "prunesafe" {
+		return s.pruneSafe(APIstub, args)
+	} else if function == "delete" {
+		return s.delete(APIstub, args)
+	} else if function == "putstandard" {
+		return s.putStandard(APIstub, args)
+	} else if function == "getstandard" {
+		return s.getStandard(APIstub, args)
+	}
+
+	return shim.Error("Invalid Smart Contract function name.")
+}
+
+/**
+ * Updates the ledger to include a new delta for a particular variable. If this is the first time
+ * this variable is being added to the ledger, then its initial value is assumed to be 0. The arguments
+ * to give in the args array are as follows:
+ *	- args[0] -> name of the variable
+ *	- args[1] -> new delta (float)
+ *	- args[2] -> operation (currently supported are addition "+" and subtraction "-")
+ *
+ * @param APIstub The chaincode shim
+ * @param args The arguments array for the update invocation
+ *
+ * @return A response structure indicating success or failure with a message
+ */
+func (s *SmartContract) update(APIstub shim.ChaincodeStubInterface, args []string) sc.Response {
+	// Check we have a valid number of args
+	if len(args) != 3 {
+		return shim.Error("Incorrect number of arguments, expecting 3")
+	}
+
+	// Extract the args
+	name := args[0]
+	op := args[2]
+	_, err := strconv.ParseFloat(args[1], 64)
+	if err != nil {
+		return shim.Error("Provided value was not a number")
+	}
+
+	// Make sure a valid operator is provided
+	if op != "+" && op != "-" {
+		return shim.Error(fmt.Sprintf("Operator %s is unrecognized", op))
+	}
+
+	// Retrieve info needed for the update procedure
+	txid := APIstub.GetTxID()
+	compositeIndexName := "varName~op~value~txID"
+
+	// Create the composite key that will allow us to query for all deltas on a particular variable
+	compositeKey, compositeErr := APIstub.CreateCompositeKey(compositeIndexName, []string{name, op, args[1], txid})
+	if compositeErr != nil {
+		return shim.Error(fmt.Sprintf("Could not create a composite key for %s: %s", name, compositeErr.Error()))
+	}
+
+	// Save the composite key index
+	compositePutErr := APIstub.PutState(compositeKey, []byte{0x00})
+	if compositePutErr != nil {
+		return shim.Error(fmt.Sprintf("Could not put operation for %s in the ledger: %s", name, compositePutErr.Error()))
+	}
+
+	return shim.Success([]byte(fmt.Sprintf("Successfully added %s%s to %s", op, args[1], name)))
+}
+
+/**
+ * Retrieves the aggregate value of a variable in the ledger. Gets all delta rows for the variable
+ * and computes the final value from all deltas. The args array for the invocation must contain the
+ * following argument:
+ *	- args[0] -> The name of the variable to get the value of
+ *
+ * @param APIstub The chaincode shim
+ * @param args The arguments array for the get invocation
+ *
+ * @return A response structure indicating success or failure with a message
+ */
+func (s *SmartContract) get(APIstub shim.ChaincodeStubInterface, args []string) sc.Response {
+	// Check we have a valid number of args
+	if len(args) != 1 {
+		return shim.Error("Incorrect number of arguments, expecting 1")
+	}
+
+	name := args[0]
+	// Get all deltas for the variable
+	deltaResultsIterator, deltaErr := APIstub.GetStateByPartialCompositeKey("varName~op~value~txID", []string{name})
+	if deltaErr != nil {
+		return shim.Error(fmt.Sprintf("Could not retrieve value for %s: %s", name, deltaErr.Error()))
+	}
+	defer deltaResultsIterator.Close()
+
+	// Check the variable existed
+	if !deltaResultsIterator.HasNext() {
+		return shim.Error(fmt.Sprintf("No variable by the name %s exists", name))
+	}
+
+	// Iterate through result set and compute final value
+	var finalVal float64
+	var i int
+	for i = 0; deltaResultsIterator.HasNext(); i++ {
+		// Get the next row
+		responseRange, nextErr := deltaResultsIterator.Next()
+		if nextErr != nil {
+			return shim.Error(nextErr.Error())
+		}
+
+		// Split the composite key into its component parts
+		_, keyParts, splitKeyErr := APIstub.SplitCompositeKey(responseRange.Key)
+		if splitKeyErr != nil {
+			return shim.Error(splitKeyErr.Error())
+		}
+
+		// Retrieve the delta value and operation
+		operation := keyParts[1]
+		valueStr := keyParts[2]
+
+		// Convert the value string and perform the operation
+		value, convErr := strconv.ParseFloat(valueStr, 64)
+		if convErr != nil {
+			return shim.Error(convErr.Error())
+		}
+
+		switch operation {
+		case "+":
+			finalVal += value
+		case "-":
+			finalVal -= value
+		default:
+			return shim.Error(fmt.Sprintf("Unrecognized operation %s", operation))
+		}
+	}
+
+	return shim.Success([]byte(strconv.FormatFloat(finalVal, 'f', -1, 64)))
+}
+
+/**
+ * Prunes a variable by deleting all of its delta rows while computing the final value. Once all rows
+ * have been processed and deleted, a single new row is added which defines a delta containing the final
+ * computed value of the variable. This function is NOT safe as any failures or errors during pruning
+ * will result in an undefined final value for the variable and loss of data. Use pruneSafe if data
+ * integrity is important. The args array contains the following argument:
+ *	- args[0] -> The name of the variable to prune
+ *
+ * @param APIstub The chaincode shim
+ * @param args The args array for the pruneFast invocation
+ *
+ * @return A response structure indicating success or failure with a message
+ */
+func (s *SmartContract) pruneFast(APIstub shim.ChaincodeStubInterface, args []string) sc.Response {
+	// Check we have a valid number of ars
+	if len(args) != 1 {
+		return shim.Error("Incorrect number of arguments, expecting 1")
+	}
+
+	// Retrieve the name of the variable to prune
+	name := args[0]
+
+	// Get all delta rows for the variable
+	deltaResultsIterator, deltaErr := APIstub.GetStateByPartialCompositeKey("varName~op~value~txID", []string{name})
+	if deltaErr != nil {
+		return shim.Error(fmt.Sprintf("Could not retrieve value for %s: %s", name, deltaErr.Error()))
+	}
+	defer deltaResultsIterator.Close()
+
+	// Check the variable existed
+	if !deltaResultsIterator.HasNext() {
+		return shim.Error(fmt.Sprintf("No variable by the name %s exists", name))
+	}
+
+	// Iterate through result set computing final value while iterating and deleting each key
+	var finalVal float64
+	var i int
+	for i = 0; deltaResultsIterator.HasNext(); i++ {
+		// Get the next row
+		responseRange, nextErr := deltaResultsIterator.Next()
+		if nextErr != nil {
+			return shim.Error(nextErr.Error())
+		}
+
+		// Split the key into its composite parts
+		_, keyParts, splitKeyErr := APIstub.SplitCompositeKey(responseRange.Key)
+		if splitKeyErr != nil {
+			return shim.Error(splitKeyErr.Error())
+		}
+
+		// Retrieve the operation and value
+		operation := keyParts[1]
+		valueStr := keyParts[2]
+
+		// Convert the value to a float
+		value, convErr := strconv.ParseFloat(valueStr, 64)
+		if convErr != nil {
+			return shim.Error(convErr.Error())
+		}
+
+		// Delete the row from the ledger
+		deltaRowDelErr := APIstub.DelState(responseRange.Key)
+		if deltaRowDelErr != nil {
+			return shim.Error(fmt.Sprintf("Could not delete delta row: %s", deltaRowDelErr.Error()))
+		}
+
+		// Add the value of the deleted row to the final aggregate
+		switch operation {
+		case "+":
+			finalVal += value
+		case "-":
+			finalVal -= value
+		default:
+			return shim.Error(fmt.Sprintf("Unrecognized operation %s", operation))
+		}
+	}
+
+	// Update the ledger with the final value and return
+	updateResp := s.update(APIstub, []string{name, strconv.FormatFloat(finalVal, 'f', -1, 64), "+"})
+	if updateResp.Status == OK {
+		return shim.Success([]byte(fmt.Sprintf("Successfully pruned variable %s, final value is %f, %d rows pruned", args[0], finalVal, i)))
+	}
+
+	return shim.Error(fmt.Sprintf("Failed to prune variable: all rows deleted but could not update value to %f, variable no longer exists in ledger", finalVal))
+}
+
+/**
+ * This function performs the same function as pruneFast except it provides data backups in case the
+ * prune fails. The final aggregate value is computed before any deletion occurs and is backed up
+ * to a new row. This back-up row is deleted only after the new aggregate delta has been successfully
+ * written to the ledger. The args array contains the following argument:
+ *	args[0] -> The name of the variable to prune
+ *
+ * @param APIstub The chaincode shim
+ * @param args The arguments array for the pruneSafe invocation
+ *
+ * @result A response structure indicating success or failure with a message
+ */
+func (s *SmartContract) pruneSafe(APIstub shim.ChaincodeStubInterface, args []string) sc.Response {
+	// Verify there are a correct number of arguments
+	if len(args) != 1 {
+		return shim.Error("Incorrect number of arguments, expecting 1 (the name of the variable to prune)")
+	}
+
+	// Get the var name
+	name := args[0]
+
+	// Get the var's value and process it
+	getResp := s.get(APIstub, args)
+	if getResp.Status == ERROR {
+		return shim.Error(fmt.Sprintf("Could not retrieve the value of %s before pruning, pruning aborted: %s", name, getResp.Message))
+	}
+
+	valueStr := string(getResp.Payload)
+	val, convErr := strconv.ParseFloat(valueStr, 64)
+	if convErr != nil {
+		return shim.Error(fmt.Sprintf("Could not convert the value of %s to a number before pruning, pruning aborted: %s", name, convErr.Error()))
+	}
+
+	// Store the var's value temporarily
+	backupPutErr := APIstub.PutState(fmt.Sprintf("%s_PRUNE_BACKUP", name), []byte(valueStr))
+	if backupPutErr != nil {
+		return shim.Error(fmt.Sprintf("Could not backup the value of %s before pruning, pruning aborted: %s", name, backupPutErr.Error()))
+	}
+
+	// Get all deltas for the variable
+	deltaResultsIterator, deltaErr := APIstub.GetStateByPartialCompositeKey("varName~op~value~txID", []string{name})
+	if deltaErr != nil {
+		return shim.Error(fmt.Sprintf("Could not retrieve value for %s: %s", name, deltaErr.Error()))
+	}
+	defer deltaResultsIterator.Close()
+
+	// Delete each row
+	var i int
+	for i = 0; deltaResultsIterator.HasNext(); i++ {
+		responseRange, nextErr := deltaResultsIterator.Next()
+		if nextErr != nil {
+			return shim.Error(fmt.Sprintf("Could not retrieve next row for pruning: %s", nextErr.Error()))
+		}
+
+		deltaRowDelErr := APIstub.DelState(responseRange.Key)
+		if deltaRowDelErr != nil {
+			return shim.Error(fmt.Sprintf("Could not delete delta row: %s", deltaRowDelErr.Error()))
+		}
+	}
+
+	// Insert new row for the final value
+	updateResp := s.update(APIstub, []string{name, valueStr, "+"})
+	if updateResp.Status == ERROR {
+		return shim.Error(fmt.Sprintf("Could not insert the final value of the variable after pruning, variable backup is stored in %s_PRUNE_BACKUP: %s", name, updateResp.Message))
+	}
+
+	// Delete the backup value
+	delErr := APIstub.DelState(fmt.Sprintf("%s_PRUNE_BACKUP", name))
+	if delErr != nil {
+		return shim.Error(fmt.Sprintf("Could not delete backup value %s_PRUNE_BACKUP, this does not affect the ledger but should be removed manually", name))
+	}
+
+	return shim.Success([]byte(fmt.Sprintf("Successfully pruned variable %s, final value is %f, %d rows pruned", name, val, i)))
+}
+
+/**
+ * Deletes all rows associated with an aggregate variable from the ledger. The args array
+ * contains the following argument:
+ *	- args[0] -> The name of the variable to delete
+ *
+ * @param APIstub The chaincode shim
+ * @param args The arguments array for the delete invocation
+ *
+ * @return A response structure indicating success or failure with a message
+ */
+func (s *SmartContract) delete(APIstub shim.ChaincodeStubInterface, args []string) sc.Response {
+	// Check there are a correct number of arguments
+	if len(args) != 1 {
+		return shim.Error("Incorrect number of arguments, expecting 1")
+	}
+
+	// Retrieve the variable name
+	name := args[0]
+
+	// Delete all delta rows
+	deltaResultsIterator, deltaErr := APIstub.GetStateByPartialCompositeKey("varName~op~value~txID", []string{name})
+	if deltaErr != nil {
+		return shim.Error(fmt.Sprintf("Could not retrieve delta rows for %s: %s", name, deltaErr.Error()))
+	}
+	defer deltaResultsIterator.Close()
+
+	// Ensure the variable exists
+	if !deltaResultsIterator.HasNext() {
+		return shim.Error(fmt.Sprintf("No variable by the name %s exists", name))
+	}
+
+	// Iterate through result set and delete all indices
+	var i int
+	for i = 0; deltaResultsIterator.HasNext(); i++ {
+		responseRange, nextErr := deltaResultsIterator.Next()
+		if nextErr != nil {
+			return shim.Error(fmt.Sprintf("Could not retrieve next delta row: %s", nextErr.Error()))
+		}
+
+		deltaRowDelErr := APIstub.DelState(responseRange.Key)
+		if deltaRowDelErr != nil {
+			return shim.Error(fmt.Sprintf("Could not delete delta row: %s", deltaRowDelErr.Error()))
+		}
+	}
+
+	return shim.Success([]byte(fmt.Sprintf("Deleted %s, %d rows removed", name, i)))
+}
+
+/**
+ * Converts a float64 to a byte array
+ *
+ * @param f The float64 to convert
+ *
+ * @return The byte array representation
+ */
+func f2barr(f float64) []byte {
+	str := strconv.FormatFloat(f, 'f', -1, 64)
+
+	return []byte(str)
+}
+
+// The main function is only relevant in unit test mode. Only included here for completeness.
+func main() {
+
+	// Create a new Smart Contract
+	err := shim.Start(new(SmartContract))
+	if err != nil {
+		fmt.Printf("Error creating new Smart Contract: %s", err)
+	}
+}
+
+/**
+ * All functions below this are for testing traditional editing of a single row
+ */
+func (s *SmartContract) putStandard(APIstub shim.ChaincodeStubInterface, args []string) sc.Response {
+	name := args[0]
+	valStr := args[1]
+
+	_, getErr := APIstub.GetState(name)
+	if getErr != nil {
+		return shim.Error(fmt.Sprintf("Failed to retrieve the statr of %s: %s", name, getErr.Error()))
+	}
+
+	putErr := APIstub.PutState(name, []byte(valStr))
+	if putErr != nil {
+		return shim.Error(fmt.Sprintf("Failed to put state: %s", putErr.Error()))
+	}
+
+	return shim.Success(nil)
+}
+
+func (s *SmartContract) getStandard(APIstub shim.ChaincodeStubInterface, args []string) sc.Response {
+	name := args[0]
+
+	val, getErr := APIstub.GetState(name)
+	if getErr != nil {
+		return shim.Error(fmt.Sprintf("Failed to get state: %s", getErr.Error()))
+	}
+
+	return shim.Success(val)
+}

--- a/fabric-kube/samples/scaled-kafka/network.yaml
+++ b/fabric-kube/samples/scaled-kafka/network.yaml
@@ -14,6 +14,8 @@ network:
   # defines which chaincodes will be installed to which organizations
   chaincodes:
     - name: very-simple
+      language: node
+      version: "1.0"
       # chaincode will be installed to all peers in these organizations
       orgs: [Karga, Nevergreen, Atlantis]
       # at which channels are we instantiating/upgrading chaincode?
@@ -23,12 +25,32 @@ network:
         # chaincode will be invoked on all peers in these organizations
         orgs: [Karga, Nevergreen, Atlantis]
         policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"function":"ping","Args":[""]}
         
     - name: even-simpler
+      language: node
+      version: "1.0"
       orgs: [Karga, Atlantis]
       channels:
       - name: private-karga-atlantis
         orgs: [Karga, Atlantis]
         policy: OR('KargaMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"function":"ping","Args":[""]}
+
+    - name: high-throughput
+      language: golang
+      version: "1.0"
+      orgs: [Karga, Nevergreen, Atlantis]
+      channels:
+      - name: common
+        orgs: [Karga, Nevergreen, Atlantis]
+        policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"Args":["update","test","1","+"]}
 
 

--- a/fabric-kube/samples/scaled-raft-tls/network.yaml
+++ b/fabric-kube/samples/scaled-raft-tls/network.yaml
@@ -17,6 +17,8 @@ network:
   # defines which chaincodes will be installed to which organizations
   chaincodes:
     - name: very-simple
+      language: node
+      version: "1.0"
       # chaincode will be installed to all peers in these organizations
       orgs: [Karga, Nevergreen, Atlantis]
       # at which channels are we instantiating/upgrading chaincode?
@@ -26,12 +28,33 @@ network:
         # chaincode will be invoked on all peers in these organizations
         orgs: [Karga, Nevergreen, Atlantis]
         policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"function":"ping","Args":[""]}
         
     - name: even-simpler
+      language: node
+      version: "1.0"
       orgs: [Karga, Atlantis]
       channels:
       - name: private-karga-atlantis
         orgs: [Karga, Atlantis]
         policy: OR('KargaMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"function":"ping","Args":[""]}
+
+    - name: high-throughput
+      language: golang
+      version: "1.0"
+      orgs: [Karga, Nevergreen, Atlantis]
+      channels:
+      - name: common
+        orgs: [Karga, Nevergreen, Atlantis]
+        policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"Args":["update","test","1","+"]}
+
 
 

--- a/fabric-kube/samples/simple-persistent/network.yaml
+++ b/fabric-kube/samples/simple-persistent/network.yaml
@@ -14,6 +14,8 @@ network:
   # defines which chaincodes will be installed to which organizations
   chaincodes:
     - name: very-simple
+      language: node
+      version: "1.0"
       # chaincode will be installed to all peers in these organizations
       orgs: [Karga, Nevergreen, Atlantis]
       # at which channels are we instantiating/upgrading chaincode?
@@ -23,12 +25,30 @@ network:
         # chaincode will be invoked on all peers in these organizations
         orgs: [Karga, Nevergreen, Atlantis]
         policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"function":"ping","Args":[""]}
         
     - name: even-simpler
+      language: node
+      version: "1.0"
       orgs: [Karga, Atlantis]
       channels:
       - name: private-karga-atlantis
         orgs: [Karga, Atlantis]
         policy: OR('KargaMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"function":"ping","Args":[""]}
 
-
+    - name: high-throughput
+      language: golang
+      version: "1.0"
+      orgs: [Karga, Nevergreen, Atlantis]
+      channels:
+      - name: common
+        orgs: [Karga, Nevergreen, Atlantis]
+        policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"Args":["update","test","1","+"]}

--- a/fabric-kube/samples/simple/network.yaml
+++ b/fabric-kube/samples/simple/network.yaml
@@ -14,6 +14,8 @@ network:
   # defines which chaincodes will be installed to which organizations
   chaincodes:
     - name: very-simple
+      language: node
+      version: "1.0"
       # chaincode will be installed to all peers in these organizations
       orgs: [Karga, Nevergreen, Atlantis]
       # at which channels are we instantiating/upgrading chaincode?
@@ -23,12 +25,30 @@ network:
         # chaincode will be invoked on all peers in these organizations
         orgs: [Karga, Nevergreen, Atlantis]
         policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"function":"ping","Args":[""]}
         
     - name: even-simpler
+      language: node
+      version: "1.0"
       orgs: [Karga, Atlantis]
       channels:
       - name: private-karga-atlantis
         orgs: [Karga, Atlantis]
         policy: OR('KargaMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"function":"ping","Args":[""]}
 
-
+    - name: high-throughput
+      language: golang
+      version: "1.0"
+      orgs: [Karga, Nevergreen, Atlantis]
+      channels:
+      - name: common
+        orgs: [Karga, Nevergreen, Atlantis]
+        policy: OR('KargaMSP.member','NevergreenMSP.member','AtlantisMSP.member')
+      invoke:
+        function: |
+          {"Args":["update","test","1","+"]}


### PR DESCRIPTION
There are a few improvements in this PR:
* Documented a resolution to the EKS issue in the FAQ.
* Changed parts of the chaincode workflow to support golang
* Allowed different language chaincode to be deployed in one network.yaml file
* Added the ability to configure metrics for peers and orderers

I used release/0.7 as a base for the changes, I wasn't sure if I could use some of the changes on master because of the patches. I can rebase these changes to a different branch if you think that makes sense.